### PR TITLE
[EOWG approved] include text in description

### DIFF
--- a/content/av-content.md
+++ b/content/av-content.md
@@ -4,7 +4,7 @@ title_image: /content-images/wai-media-guide/av-content.svg
 nav_title: "Audio Content & Video Content"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2020-10-01   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2020-11-24   # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -27,7 +27,7 @@ description: Describes accessibility considerations when planning, scripting, st
 image: /content-images/wai-media-guide/social.png
 
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated 1 October 2020. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated 24 November 2020. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 

--- a/content/av-content.md
+++ b/content/av-content.md
@@ -133,7 +133,7 @@ For other guidance including recording, see another page of this resource: [Sign
 
 ### Plan for audio description of visual information – _storyboarding, recording_  (WCAG A, AA) {#plan-description}
 
-_Description_ provides content to people who are blind and others who cannot see the video adequately. It describes the visual information needed to understand the content.
+_Description_ provides content to people who are blind and others who cannot see the video adequately. It describes the visual information needed to understand the content, **including text displayed in the video**.
 
 Plan to either:
 * Integrate description of the visual information that users need to understand into the main audio content,<br>_**or**_

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -3,7 +3,7 @@ title: "Changelog"
 nav_title: "Changelog"
 
 lang: en
-last_updated: 2020-10-01
+last_updated: 2020-11-24
 
 permalink: /media/av/changelog/
 ref: /media/av/changelog/   # Do not change
@@ -18,6 +18,14 @@ resource:
 navigation:
 
 ---
+
+## 2020-November-24
+
+* In Audio Description of Visual Information page, under [Tips for Writing Descriptions](https://www.w3.org/WAI/media/av/description/#writing), added paragraph:<br>"Generally, all text in the video should be included in the main audio (integrated description) or in the separate description. For example, title text at the beginning of the video, links and e-mail addresses shown at the end, speakers’ names in text, and text in a presentation. The text does not have to be included verbatim (exactly word-for-word), yet all of the information conveyed by the text needs to be available in the main audio, in the separate description, or clearly with the video."
+* In first page, under [How to Make Audio and Video Accessible](https://www.w3.org/WAI/media/av/#how-to-make-audio-and-video-accessible), at end of Audio Description of Visual Information paragraph, added:<br>", including text displayed in the video."
+* In Audio Content and Video Content page, under [Plan for audio description of visual information](https://www.w3.org/WAI/media/av/av-content/#plan-description), at end of first paragraph, added:<br>", **including text displayed in the video**."
+
+([Diff for text in description](https://github.com/w3c/wai-media-guide/pull/126/files))
 
 ## 2020-October-1
 

--- a/content/description.md
+++ b/content/description.md
@@ -5,7 +5,7 @@ title_image: /content-images/wai-media-guide/ad.svg
 nav_title: "Description"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2019-10-10   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2020-11-24   # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -28,7 +28,7 @@ description: Helps you understand and create description of visual information (
 image: /content-images/wai-media-guide/social.png
 
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated @@ October 2019. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated 24 November 2020. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 

--- a/content/description.md
+++ b/content/description.md
@@ -272,7 +272,7 @@ The process to develop a separate audio file and edit the visual track is basica
 * Describe objectively, without interpretation, censorship, or comment.
 * Write description in present tense, active voice, and third-person narrative style.
 
-Generally, all text in the video should be included in the main audio (integrated description) or in the separate description. For example, title text at the beginning of the video, links and e-mail addresses shown at the end, speakers' names in text, and text in a presentation. The text does not have to be included verbatim (exactly word-for-word), yet all of the information conveyed by the text needs to be available in the main audio or in the separate description.
+Generally, all text in the video should be included in the main audio (integrated description) or in the separate description. For example, title text at the beginning of the video, links and e-mail addresses shown at the end, speakers' names in text, and text in a presentation. The text does not have to be included verbatim (exactly word-for-word), yet all of the information conveyed by the text needs to be available in the main audio, in the separate description, or clearly with the video.
 
 More guidance on writing descriptions is available on the web, for example: [Description Tip Sheet {% include_cached external.html %}](https://dcmp.org/learn/227) and [How to Describe {% include_cached external.html %}](http://www.descriptionkey.org/how_to_describe.html).
 

--- a/content/description.md
+++ b/content/description.md
@@ -272,6 +272,8 @@ The process to develop a separate audio file and edit the visual track is basica
 * Describe objectively, without interpretation, censorship, or comment.
 * Write description in present tense, active voice, and third-person narrative style.
 
+Generally, all text in the video should be included in the main audio (integrated description) or in the separate description. For example, title text at the beginning of the video, links and e-mail addresses shown at the end, speakers' names in text, and text in a presentation. The text does not have to be included verbatim (exactly word-for-word), yet all of the information conveyed by the text needs to be available in the main audio or in the separate description.
+
 More guidance on writing descriptions is available on the web, for example: [Description Tip Sheet {% include_cached external.html %}](https://dcmp.org/learn/227) and [How to Describe {% include_cached external.html %}](http://www.descriptionkey.org/how_to_describe.html).
 
 ### Tips for Recording Descriptions {#recording}

--- a/content/description.md
+++ b/content/description.md
@@ -5,7 +5,7 @@ title_image: /content-images/wai-media-guide/ad.svg
 nav_title: "Description"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2019-09-10   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2019-10-10   # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -28,7 +28,7 @@ description: Helps you understand and create description of visual information (
 image: /content-images/wai-media-guide/social.png
 
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated 10 September 2019. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated @@ October 2019. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 

--- a/content/index.md
+++ b/content/index.md
@@ -86,7 +86,7 @@ Most default browser media players have limited functionality to support accessi
 
 Specific guidance for other aspects of making your media accessible are in the following pages:
 
-* {:.left} [{% include image.html src="ad.svg" alt="" %} Audio Description of Visual Information](/media/av/description/) &mdash; Description provides content to people who are blind and others who cannot see the video adequately. It describes visual information needed to understand the content.
+* {:.left} [{% include image.html src="ad.svg" alt="" %} Audio Description of Visual Information](/media/av/description/) &mdash; Description provides content to people who are blind and others who cannot see the video adequately. It describes visual information needed to understand the content, including text displayed in the video.
 
 * {:.left} [{% include image.html src="cc.svg" alt="" %} Captions/Subtitles](/media/av/captions/) &mdash; Captions (also called "subtitles") provide content to people who are Deaf and hard-of-hearing. Captions are a text version of the speech and non-speech audio information needed to understand the content. They are synchronized with the audio and usually shown in a media player when users turn them on.
 

--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ title: "Making Audio and Video Media Accessible"
 nav_title: "Audio & Video Media"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2019-11-18   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2020-11-24  # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -26,7 +26,7 @@ description: Covers captions/subtitles, audio description of visual information,
 image: /content-images/wai-media-guide/social.png
  
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated 18 November 2019. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated 24 November 2020. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 


### PR DESCRIPTION
Goal: Make more explicitly clear that text in video needs to be available in alternative format. 