### PR TITLE
quick tips as a separate page with DL

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -44,7 +44,7 @@ Accessible audio and video is essential for people with disabilities, and benefi
 * **[Describe visual information](/media/av/player/)** -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.
 * **Provide [captions](/media/av/captions/)** (called “**subtitles**” in some areas) so that people who are Deaf or hard-of-hearing get a synchronized text version of the speech and other audio information needed to understand the content.
 * **Provide a [text transcript](/media/av/transcripts/)** from the caption text and the description of visual information so that people who are Deaf-blind get the video content.
-* **Provide [sign language](/media/av/sign-languages/)** so that Deaf people whose native language is sign get the content in their language.
+* **Provide [sign language](/media/av/sign-languages/)** so that Deaf people whose native language is sign get the content in their native language.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ title: "Making Audio and Video Media Accessible"
 nav_title: "Audio & Video Media"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2020-12-20   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2020-12-10   # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -26,7 +26,7 @@ description: Covers captions/subtitles, audio description of visual information,
 image: /content-images/wai-media-guide/social.png
  
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated @@ December 2020. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated 10 December 2020. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 
@@ -39,12 +39,12 @@ footer: >   # Translate words below, including "Date:" and "Editor:". (Do not up
 Accessible audio and video is essential for people with disabilities, and benefits organizations. This resource describes accessibility requirements in Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/media/av/planning/#wcag-standard)) and good practices beyond WCAG. It helps you:
 
 * **[Plan](/media/av/planning/) for accessibility from the very start** of your project (before recording), to save time and money. Use [checklists](/media/av/planning/#checklist).
-* **Make [audio and video content](/media/av/av-content/) accessible**. Avoid accessibility barriers when **scripting, storyboarding, and recording** content.
-* Use a [media player](/media/av/player/) that supports accessibility.
+* **Make [audio and video content](/media/av/av-content/) accessible**. Avoid accessibility barriers when scripting, storyboarding, and recording content.
+* **Use a [media player](/media/av/player/) that supports accessibility**.
 * **[Describe visual information](/media/av/player/)** -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.
 * **Provide [captions](/media/av/captions/)** (called “**subtitles**” in some areas) so that people who are Deaf or hard-of-hearing get a synchronized text version of the speech and other audio information needed to understand the content.
 * **Provide a [text transcript](/media/av/transcripts/)** from the caption text and the description of visual information so that people who are Deaf-blind get the video content.
-* Provide [sign language](/media/av/sign-languages/) so that Deaf people whose native language is sign get the content in their language.
+* **Provide [sign language](/media/av/sign-languages/)** so that Deaf people whose native language is sign get the content in their language.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/content/index.md
+++ b/content/index.md
@@ -38,7 +38,7 @@ footer: >   # Translate words below, including "Date:" and "Editor:". (Do not up
 
 Accessible audio and video is essential for people with disabilities, and benefits organizations. This resource describes accessibility requirements in Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/media/av/planning/#wcag-standard)) and good practices beyond WCAG. It helps you:
 
-* **[Plan](/media/av/planning/) for accessibility from the very start** of your project (before recording), to save time and money. Use [checklists](/media/av/planning/#checklist).
+* **[Plan](/media/av/planning/) for accessibility from the very start** of your project (before recording), to save time and money.
 * **Make [audio and video content](/media/av/av-content/) accessible**. Avoid accessibility barriers when scripting, storyboarding, and recording content.
 * **Use a [media player](/media/av/player/) that supports accessibility**.
 * **[Describe visual information](/media/av/player/)** -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.

--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ title: "Making Audio and Video Media Accessible"
 nav_title: "Audio & Video Media"
 
 lang: en   # change "en" to lang code, here and 2 @@s below
-last_updated: 2019-11-18   # Change to date of translation YYYY-MM-DD (month in middle)
+last_updated: 2020-12-20   # Change to date of translation YYYY-MM-DD (month in middle)
 # translator: "..."
 # contributors: "..."
 
@@ -26,18 +26,25 @@ description: Covers captions/subtitles, audio description of visual information,
 image: /content-images/wai-media-guide/social.png
  
 footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
-   <p><strong>Date:</strong> Updated 18 November 2019. CHANGELOG.</p>
+   <p><strong>Date:</strong> Updated @@ December 2020. CHANGELOG.</p>
    <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
    <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
 
 ---
 
-
 {::nomarkdown}
 {% include box.html type="start" title="Summary" class="" %}
 {:/}
 
-Accessible audio and video is essential for people with disabilities, and benefits organizations. Depending on the content of your media, it might need **captions/subtitles** (a text version of the audio that is shown synchronized in the media player), a **transcript** (a separate text version of the audio), **audio description of visual information** (usually an additional audio stream that describes important visual content), **or other** accessibility functionality/features.
+Accessible audio and video is essential for people with disabilities, and benefits organizations. This resource describes accessibility requirements in Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/media/av/planning/#wcag-standard)) and good practices beyond WCAG. It helps you:
+
+* [Plan](/media/av/planning/) for accessibility from the very start of your project (before recording), to save time and money. Use [checklists](/media/av/planning/#checklist).
+* Make [audio and video content](/media/av/av-content/) accessible. Avoid accessibility barriers when planning, scripting, storyboarding, recording, and producing content.
+* Use a [media player](/media/av/player/) that supports accessibility.
+* [Describe visual information](/media/av/player/) -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.
+* Provide [captions](/media/av/captions/) (called “subtitles” in some areas) so that people who are Deaf and hard-of-hearing get a synchronized text version of the speech and other audio information needed to understand the content.
+* Provide a [text transcript](/media/av/transcripts/) from the caption text and the description of visual information so that people who are Deaf and blind get the video content.
+* Plan for [sign language](/media/av/sign-languages/) so that some people who are Deaf get the audio content in their native language.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/content/index.md
+++ b/content/index.md
@@ -38,13 +38,13 @@ footer: >   # Translate words below, including "Date:" and "Editor:". (Do not up
 
 Accessible audio and video is essential for people with disabilities, and benefits organizations. This resource describes accessibility requirements in Web Content Accessibility Guidelines ([WCAG](https://www.w3.org/WAI/media/av/planning/#wcag-standard)) and good practices beyond WCAG. It helps you:
 
-* [Plan](/media/av/planning/) for accessibility from the very start of your project (before recording), to save time and money. Use [checklists](/media/av/planning/#checklist).
-* Make [audio and video content](/media/av/av-content/) accessible. Avoid accessibility barriers when planning, scripting, storyboarding, recording, and producing content.
+* **[Plan](/media/av/planning/) for accessibility from the very start** of your project (before recording), to save time and money. Use [checklists](/media/av/planning/#checklist).
+* **Make [audio and video content](/media/av/av-content/) accessible**. Avoid accessibility barriers when **scripting, storyboarding, and recording** content.
 * Use a [media player](/media/av/player/) that supports accessibility.
-* [Describe visual information](/media/av/player/) -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.
-* Provide [captions](/media/av/captions/) (called “subtitles” in some areas) so that people who are Deaf and hard-of-hearing get a synchronized text version of the speech and other audio information needed to understand the content.
-* Provide a [text transcript](/media/av/transcripts/) from the caption text and the description of visual information so that people who are Deaf and blind get the video content.
-* Plan for [sign language](/media/av/sign-languages/) so that some people who are Deaf get the audio content in their native language.
+* **[Describe visual information](/media/av/player/)** -- such as charts and speakers’ names in text -- so that people who are blind and others who cannot see the video get the visual information needed to understand the content.
+* **Provide [captions](/media/av/captions/)** (called “**subtitles**” in some areas) so that people who are Deaf or hard-of-hearing get a synchronized text version of the speech and other audio information needed to understand the content.
+* **Provide a [text transcript](/media/av/transcripts/)** from the caption text and the description of visual information so that people who are Deaf-blind get the video content.
+* Provide [sign language](/media/av/sign-languages/) so that Deaf people whose native language is sign get the content in their language.
 
 {::nomarkdown}
 {% include box.html type="end" %}

--- a/content/quicktips.md
+++ b/content/quicktips.md
@@ -58,6 +58,3 @@ footer: >   # Translate words below, including "Date:" and "Editor:". (Do not up
 {:.paragraph-like}
 
 **Learn more about [[Making Audio and Video Media Accessible]](/media/av/).**
-
-
-@@ add movement to AV content

--- a/content/quicktips.md
+++ b/content/quicktips.md
@@ -1,0 +1,63 @@
+---
+title: "Quick Tips for A/V Media Accessibility"
+# title_image: /content-images/wai-media-guide/av-content.svg @@SLH get/make new image
+nav_title: "Quick Tips for A/V Media Accessibility"
+
+lang: en   # change "en" to lang code, here and 2 @@s below
+last_updated: 2020-11-24   # Change to date of translation YYYY-MM-DD (month in middle)
+# translator: "..."
+# contributors: "..."
+
+permalink: /media/av/quicktips/   # Add lang to end /link/to/page/@@
+ref: /media/av/quicktips /   # Do not change this
+layout: default
+github:
+   repository: w3c/wai-media-guide
+   path: 'content/quicktips.md'   # Add lang to the middle of the filename, e.g., index.@@.md
+
+resource:
+  ref: /media/av/
+navigation:
+  previous: /media/av/
+  next:     /media/av/planning/
+changelog: /media/av/changelog/
+acknowledgements: /media/av/acknowledgements/
+  
+description: Quick tips for making audio and video material accessible to people with disabilities.
+image: /content-images/wai-media-guide/social.png
+
+footer: >   # Translate words below, including "Date:" and "Editor:". (Do not update the date.)
+   <p><strong>Date:</strong> Updated 24 November 2020. CHANGELOG.</p>
+   <p><strong>Editor:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a>. ACKNOWLEDGEMENTS lists contributors and credits.</p>
+   <p>Developed by the Education and Outreach Working Group (<a href="http://www.w3.org/WAI/EO/">EOWG</a>). Originally drafted as part of the <a href="https://www.w3.org/WAI/WCAGTA/">WCAG TA Project</a> funded by the <abbr title="United States">U.S.</abbr> Access Board. Revised as part of the <a href="https://www.w3.org/WAI/expand-access/">WAI Expanding Access project</a> funded by the Ford Foundation.</p>
+
+---
+
+[[Captions/Subtitles]](/media/av/captions/)
+: Provide captions (also called “subtitles”) so that people who are Deaf and hard-of-hearing get a text version of the speech and non-speech audio information needed to understand the content.
+
+[[Audio Description of Visual Information]](/media/av/description/)
+: Provide description so that people who are blind and others who cannot see the video adequately get the visual information needed to understand the content. This includes things like charts, graphs, and text such as speaker names, titles, and e-mail addresses.
+
+[[Transcripts]](/media/av/transcripts/)
+: Provide a transcript, that is, a text version of the speech and non-speech audio information. Ideally, make it a descriptive transcript that also includes text description of the visual information. Descriptive transcripts are required to provide video content to people who are both Deaf and blind. ([descriptive transcript excerpt example](/WAI/media/av/transcripts/#descriptive))
+
+[[Audio Content and Video Content]](/media/av/av-content/)
+: When planning, scripting, storyboarding, recording, and producing media:
+* Create high-quality audio and use low background noise.
+* Speak clearly and slowly, and use clear language.
+* Make any text readable, with good contrast and text size.
+* Plan for audio description of visual information.
+
+
+[[Media Players]](/media/av/player/)
+: Use a media player that supports accessibility.
+
+[[Planning Audio and Video Media]](/media/av/planning/)
+: Plan for accessibility from the very start of your project, to save time and money. For example, [integrated description](/media/av/av-content/#integrate-description) is easier and better for accessibility, and it needs to be included in the script before filming.
+{:.paragraph-like}
+
+**Learn more about [[Making Audio and Video Media Accessible]](/media/av/).**
+
+
+@@ add movement to AV content


### PR DESCRIPTION
See: **[Quick Tips draft page](https://deploy-preview-143--wai-media-guide.netlify.app/media/av/quicktips/)**

EOWG, please comment below on things like:
* Pros and cons to having a page like this?
* Comments on this draft format, length, tone, etc.?
* Order of topics? (here it's more order of importance for those making videos; which is a different order from the [main resource](https://www.w3.org/WAI/media/av/#how-to-make-audio-and-video-accessible))
* What about sign language?
* Title ideas?