### PR TITLE
Add missing info for pre-recorded video with audio

### DIFF
--- a/content/planning.md
+++ b/content/planning.md
@@ -332,11 +332,12 @@ The links in the tables below go to a page in a separate resource: Understanding
 </tr>
 <tr>
   <th scope="row">Video with Audio</th>
-  <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded">AAA 1.2.8</a></td>
+  <td><strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded">A 1.2.3</a></strong>&nbsp;(transcript <em><strong>or</strong></em> audio description)<br>
+    <a href="https://www.w3.org/WAI/WCAG21/Understanding/media-alternative-prerecorded">AAA 1.2.8</a></td>
   <td><strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded">A 1.2.2</a></strong></td>
   <td><strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-or-media-alternative-prerecorded">A 1.2.3</a></strong>&nbsp;(audio description <em><strong>or</strong></em> transcript)<br>
     <strong><a href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded">AA 1.2.5</a></strong><br>
-    <a href="https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded">AAA 1.2.7</a></td>
+    <a href="https://www.w3.org/WAI/WCAG21/Understanding/extended-audio-description-prerecorded">AAA 1.2.7</a> (and extended audio description, if applicable)</td>
   <td><a href="https://www.w3.org/WAI/WCAG21/Understanding/sign-language-prerecorded">AAA 1.2.6</a></td>
 </tr>
 </table>


### PR DESCRIPTION
The table at the bottom of the ['Planning Audio and Video Media' page](https://www.w3.org/WAI/media/av/planning/#pre-recorded) that summarises what WCAG says about time-based media is missing two things which this PR adds:

* 1.2.3 is already mentioned under audio description that it's also valid for transcripts. But it is missing from the transcript column.
* 1.2.7 is missing information about extended audio descriptions. Not sure if it was potentially left out intentionally to save space?