### PR TITLE
Change empty table header to data cell

### DIFF
--- a/content/planning.md
+++ b/content/planning.md
@@ -309,7 +309,7 @@ The links in the tables below go to a page in a separate resource: Understanding
 
 <table class="quiet">
 <tr>
-<th scope="col">&nbsp;</th>
+<td>&nbsp;</td>
 <th scope="col">Transcript <span class="normal-weight">(including auditory and visual content)</span></th>
 <th scope="col">Captions</th>
 <th scope="col">Audio Description <span class="normal-weight">(if visual content not in audio)</span></th>
@@ -346,7 +346,7 @@ The links in the tables below go to a page in a separate resource: Understanding
 
 <table class="quiet">
 <tr>
-<th scope="col">&nbsp;</th>
+<td>&nbsp;</td>
 <th scope="col">Transcript</th>
 <th scope="col">Captions</th>
 <th scope="col">Audio Description</th>


### PR DESCRIPTION
Table headers should never be empty. This changes the empty table header cell in the two time-based media summary tables at the bottom of the ['Planning Audio and Video Media' page](https://www.w3.org/WAI/media/av/planning/#pre-recorded) to be simple data cells. This follows the ['Table with Two Headers' example](https://www.w3.org/WAI/tutorials/tables/two-headers/) from W3C's tables tutorial.